### PR TITLE
Add TutorialSearch to Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A curated list of awesome resources related to *Soccer Analytics* in *english* a
 * [Posgrado en Sports Analytics](https://www.talent.upc.edu/esp/estudis/formacio/curs/303600/postgrau-sports-analytics/): Universitat Politècnica de Catalunya
 * [Soccer Analytics Handbook](https://github.com/devinpleuler/analytics-handbook): Getting started with soccer analytics
 * [StatsBomb Courses](https://courses.statsbomb.com/: StatsBomb courses are delivered by video and webinar
-* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+* [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/cloud-analytics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Events & Conferences
 * [Carnegie Mellon Sports Analytics Conference](http://www.cmusportsanalytics.com/conference2018.html)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of awesome resources related to *Soccer Analytics* in *english* a
 * [Posgrado en Sports Analytics](https://www.talent.upc.edu/esp/estudis/formacio/curs/303600/postgrau-sports-analytics/): Universitat Politècnica de Catalunya
 * [Soccer Analytics Handbook](https://github.com/devinpleuler/analytics-handbook): Getting started with soccer analytics
 * [StatsBomb Courses](https://courses.statsbomb.com/: StatsBomb courses are delivered by video and webinar
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Events & Conferences
 * [Carnegie Mellon Sports Analytics Conference](http://www.cmusportsanalytics.com/conference2018.html)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Education* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/cloud-analytics) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/cloud-analytics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.